### PR TITLE
Issue 9

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Export SMF",
     "description": "Export to SMF 10 (SnidrsModelFormat)",
     "author": "Bart Teunis",
-    "version": (0, 8, 1),
+    "version": (0, 9, 0),
     "blender": (2, 80, 0),
     "location": "File > Export",
     "warning": "",  # used for warning icon and text in addons panel

--- a/debug.py
+++ b/debug.py
@@ -1,0 +1,11 @@
+# A couple of functions to make debugging easier
+#
+
+def format_iterable(iterable):
+    formatted = ["{:4.4f}".format(item) for item in iterable]
+    return "[" + ", ".join(formatted) + "]"
+
+def print_dq_list(list, index_header, value_header):
+    print(index_header, " - ", value_header)
+    for i, dq in enumerate(list):
+        print("{:2d}".format(i), " - ", format_iterable(dq))

--- a/export_smf.py
+++ b/export_smf.py
@@ -541,9 +541,9 @@ def export_smf(operator, context,
             track.mute = mute_prev[i]
 
     # Now build header
-    header_bytes = bytearray("SMF_v10_by_Snidr_and_Bart\0", 'utf-8')
+    header_bytes = bytearray("SMF_v11_by_Snidr_and_Bart\0", 'utf-8')
 
-    tex_pos = len(header_bytes) + calcsize('IIIIII')
+    tex_pos = len(header_bytes) + calcsize('IIIII')
     mod_pos = tex_pos + len(texture_bytes)
     rig_pos = mod_pos + len(model_bytes)
     ani_pos = rig_pos + len(rig_bytes)

--- a/export_smf.py
+++ b/export_smf.py
@@ -208,6 +208,14 @@ def export_smf(operator, context,
             # Add the world transform to the nodes, ignore scale
             mat_w = apply_world_matrix(matrix, rig_object.matrix_world)
 
+            m = mat_w.to_3x3()  # Verify orthogonality of upper 3x3
+            print(m)
+            print(m.is_orthogonal)
+            print(m.is_orthogonal_axis_vectors)
+
+            dq = dq_negate(dq_create_matrix(mat_w)) # negate != invert (!!)
+            print(dq_to_tuple_xyzw(dq))
+
             # Construct a list containing matrix values in the right order
             vals = [j for i in mat_w.col for j in i]
 

--- a/export_smf.py
+++ b/export_smf.py
@@ -575,7 +575,7 @@ def fix_keyframe_dq(dq, frame_index, node_index):
         dq = dq_multiply(local_dq_conj, pose_local_dq)
 
         if frame_index == 0:
-            if dq[3] < 0:
+            if dq.real.w < 0:
                 dq_negate(dq)
         else:
             if prevframe.real.dot(dq.real) < 0:

--- a/export_smf.py
+++ b/export_smf.py
@@ -220,7 +220,7 @@ def export_smf(operator, context,
 
             # print(n)
             #
-            # dq = dq_negate(dq_create_matrix(mat_w)) # negate != invert (!!)
+            dq = dq_negate(dq_create_matrix(mat_w)) # negate != invert (!!)
             # print(format_iterable(dq_to_tuple_xyzw(dq)))
 
             # if b.parent:

--- a/export_smf.py
+++ b/export_smf.py
@@ -1,6 +1,6 @@
 # SMF export scripts for Blender
 #
-from .pydq import dq_create_matrix, dq_to_tuple_xyzw
+from .pydq import dq_create_matrix, dq_negate, dq_to_tuple_xyzw
 import bpy
 from struct import Struct, pack, calcsize
 from mathutils import *
@@ -423,10 +423,10 @@ def export_smf(operator, context,
                 mat.translation = bone.tail[:]
                 mat_final = apply_world_matrix(mat, rig_object.matrix_world)
                 mat_final.normalize()
-                m = mat_final.to_3x3()
-                dq = dq_create_matrix(mat_final)
-                print(m)
+                dq = dq_negate(dq_create_matrix(mat_final)) # negate != invert (!!)
                 print(dq_to_tuple_xyzw(dq))
+                # m = mat_final.to_3x3()  # Verify orthogonality of upper 3x3
+                # print(m)
                 # print(m.is_orthogonal)
                 # print(m.is_orthogonal_axis_vectors)
                 vals = [j for i in mat_final.col for j in i]

--- a/export_smf.py
+++ b/export_smf.py
@@ -217,9 +217,10 @@ def export_smf(operator, context,
             print(dq_to_tuple_xyzw(dq))
 
             # Construct a list containing matrix values in the right order
-            vals = [j for i in mat_w.col for j in i]
+            # vals = [j for i in mat_w.col for j in i]
+            vals = dq_to_tuple_xyzw(dq)
 
-            rig_bytes.extend(pack('f'*16, *vals))
+            rig_bytes.extend(pack('f'*len(vals), *vals))
             rig_bytes.extend(pack('B',parent_bone_index))       # node[@ eAnimNode.Parent]
             rig_bytes.extend(pack('B',connected))               # node[@ eAnimNode.IsBone]
             rig_bytes.extend(pack('B',False))                   # node[@ eAnimNode.Locked]
@@ -440,8 +441,9 @@ def export_smf(operator, context,
                 # print(m)
                 # print(m.is_orthogonal)
                 # print(m.is_orthogonal_axis_vectors)
-                vals = [j for i in mat_final.col for j in i]
-                byte_data.extend(pack('f'*16, *vals))
+                # vals = [j for i in mat_final.col for j in i]
+                vals = dq_to_tuple_xyzw(dq)
+                byte_data.extend(pack('f'*len(vals), *vals))
 
         # Restore frame position
         scene.frame_set(frame_prev)
@@ -548,14 +550,14 @@ def export_smf(operator, context,
 def fix_keyframe_dq(dq, frame_index, node_index):
     """Fix the keyframe DQ to make sure the animation doesn't look choppy"""
     if node_index > 0:
-        pose_local_dq = dq_multiply(dq_get_conjugate())
+        pose_local_dq = dq_multiply(dq_get_conjugate(dq), dq)
         dq = dq_multiply(local_dq_conj, pose_local_dq)
 
         if frame_index == 0:
             if dq[3] < 0:
                 dq_negate(dq)
         else:
-            if dot(prevframe.real, dq.real):
+            if prevframe.real.dot(dq.real) < 0:
                 dq_negate(dq)
     else:
         dq = dq_get_product(world_dq_conjugate, dq)

--- a/export_smf.py
+++ b/export_smf.py
@@ -16,7 +16,7 @@ from .pydq import (
     dq_to_tuple_xyzw,
 )
 
-SMF_version = 10    # SMF 'export' version
+SMF_version = 11    # SMF 'export' version
 SMF_format_struct = Struct("ffffffffBBBBBBBBBBBB")  # 44 bytes
 SMF_format_size = SMF_format_struct.size
 

--- a/export_smf.py
+++ b/export_smf.py
@@ -1,6 +1,6 @@
 # SMF export scripts for Blender
 #
-#from .pydq import dq_create_matrix_vector, dq_to_tuple_smf
+from .pydq import dq_create_matrix, dq_to_tuple_xyzw
 import bpy
 from struct import Struct, pack, calcsize
 from mathutils import *
@@ -422,6 +422,13 @@ def export_smf(operator, context,
 
                 mat.translation = bone.tail[:]
                 mat_final = apply_world_matrix(mat, rig_object.matrix_world)
+                mat_final.normalize()
+                m = mat_final.to_3x3()
+                dq = dq_create_matrix(mat_final)
+                print(m)
+                print(dq_to_tuple_xyzw(dq))
+                # print(m.is_orthogonal)
+                # print(m.is_orthogonal_axis_vectors)
                 vals = [j for i in mat_final.col for j in i]
                 byte_data.extend(pack('f'*16, *vals))
 

--- a/export_smf.py
+++ b/export_smf.py
@@ -174,7 +174,7 @@ def export_smf(operator, context,
 
     if not rig:
         # No (valid) armature for export
-        rig_bytes.extend(pack('B', 0))
+        rig_bytes.extend(pack('I', 0))                              # nodeNum
     else:
         # Construct node list for SMF
         # (heads of disconnected bones need to become nodes, too)
@@ -184,7 +184,7 @@ def export_smf(operator, context,
         bindmap = smf_bindmap(bones)
         bone_names = bindmap.keys()
 
-        rig_bytes.extend(pack('B',len(bones)))                      # nodeNum
+        rig_bytes.extend(pack('I', len(bones)))                     # nodeNum
 
         if not rig.bones:
             #self.report({'WARNING'},"Armature has no bones. Exporting empty rig.")
@@ -242,7 +242,7 @@ def export_smf(operator, context,
             vals = dq_to_tuple_xyzw(dq)
 
             rig_bytes.extend(pack('f'*len(vals), *vals))
-            rig_bytes.extend(pack('B',parent_bone_index))       # node[@ eAnimNode.Parent]
+            rig_bytes.extend(pack('I',parent_bone_index))       # node[@ eAnimNode.Parent]
             rig_bytes.extend(pack('B',connected))               # node[@ eAnimNode.IsBone]
             rig_bytes.extend(pack('B',False))                   # node[@ eAnimNode.Locked]
             rig_bytes.extend(pack('fff',*(0, 0, 0)))            # Primary IK axis (default all zeroes)

--- a/pydq.py
+++ b/pydq.py
@@ -77,10 +77,25 @@ def dq_normalize(dq):
     dq.dual[3] = (dq.dual[3] - dq.real[3] * d) * l
     return dq
 
+def dq_negate(dq):
+    """Negate a dual quaternion"""
+    dq.real.negate()
+    dq.dual.negate()
+    return dq
+
+def dq_invert(dq):
+    """Invert a dual quaternion"""
+    pass
+
 def dq_to_tuple_xyzw(dq):
-    """Return the tuple representation of the given DQ for use with SMF"""
+    """Return the tuple representation of the given DQ with w last (e.g. for use with SMF)"""
     return (dq.real.x, dq.real.y, dq.real.z, dq.real.w,
             dq.dual.x, dq.dual.y, dq.dual.z, dq.dual.w,)
+
+def dq_to_tuple_wxyz(dq):
+    """Return the tuple representation of the given DQ with w first"""
+    return (dq.real.w, dq.real.x, dq.real.y, dq.real.z,
+            dq.dual.w, dq.dual.x, dq.dual.y, dq.dual.z,)
 
 def dq_get_translation(dq):
     pass

--- a/pydq.py
+++ b/pydq.py
@@ -95,6 +95,10 @@ def dq_invert(dq):
     """Invert a dual quaternion"""
     pass
 
+def quat_to_tuple_xyzw(quat):
+    """Convert a mathutils.Quaternion to a tuple with components ordered xyzw"""
+    return (quat.x, quat.y, quat.z, quat.w)
+
 def dq_to_tuple_xyzw(dq):
     """Return the tuple representation of the given DQ with w last (e.g. for use with SMF)"""
     return (dq.real.x, dq.real.y, dq.real.z, dq.real.w,

--- a/pydq.py
+++ b/pydq.py
@@ -78,10 +78,14 @@ def dq_normalize(dq):
     return dq
 
 def dq_negate(dq):
-    """Negate a dual quaternion"""
+    """Negate a dual quaternion, i.e. negate both real and dual components"""
     dq.real.negate()
     dq.dual.negate()
     return dq
+
+def dq_negated(dq):
+    """Return a new dual quaternion that is the negated dual quaternion"""
+    return DQ(-dq.real, -dq.dual)
 
 def dq_invert(dq):
     """Invert a dual quaternion"""

--- a/pydq.py
+++ b/pydq.py
@@ -3,11 +3,15 @@
 # DQs are stored as a named tuple of 2 Quaternions
 # and can be converted to a tuple for export to SMF using dq_to_tuple_xyzw
 #
-import bpy
 from collections import namedtuple
 from mathutils import Quaternion
 
-DQ = namedtuple('DQ', 'real dual')
+# TODO Derive from typing.NamedTuple? Use dataclasses.dataclass?
+DQ = namedtuple(
+    'DQ',
+    "real dual",
+    defaults=[Quaternion(), Quaternion((0, 0, 0, 0))]
+)
 
 def dq_create_identity():
     """Return a new identity DQ"""


### PR DESCRIPTION
* Fixed issue #9 Dual quaternion support (+ improvements to DQ functions in pydq.py)
* Various additions and snippets of code added in comments that might still be useful in the future
* SMF version 11, exporter version 0.9.0
* Node number datatype changed to uint (4 bytes) (see #10)