### PR TITLE
Prevent None values appearing in the list of animations to be exported

### DIFF
--- a/export_smf.py
+++ b/export_smf.py
@@ -163,6 +163,10 @@ def export_smf(operator, context,
             else:
                 pass
 
+    # Make sure we don't try to export actions that look like they're linked
+    # but don't exist anymore
+    animations.discard(None)
+
     # Initalize variables that we need across chunks
     bindmap = {}
     bone_names = []
@@ -499,6 +503,8 @@ def export_smf(operator, context,
 
     animation_bytes.extend(pack('B', len(animations)))
     for anim in animations:
+        print(anim)
+
         # Remember state
         anim_data = rig_object.animation_data
         action_prev = anim_data.action


### PR DESCRIPTION
This threw an error further down in the code: 
```
Python: Traceback (most recent call last):
  File "C:\Users\SnidrHub\AppData\Roaming\Blender Foundation\Blender\2.91\scripts\addons\blender-to-smf-09\__init__.py", line 150, in execute
    return export_smf(self, context, **keywords)
  File "C:\Users\SnidrHub\AppData\Roaming\Blender Foundation\Blender\2.91\scripts\addons\blender-to-smf-09\export_smf.py", line 515, in export_smf
    kf_times = sorted({p.co[0] for fcurve in anim_data.action.fcurves for p in fcurve.keyframe_points})
AttributeError: 'NoneType' object has no attribute 'fcurves'

location: <unknown location>:-1
```